### PR TITLE
relax numpy/scipy version spec - fixes #34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/scottrini/OctoPrint-PrusaLevelingguide"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ['regex', 'numpy==1.16.6', 'scipy==1.2.3']
+plugin_requires = ['regex', 'numpy~=1.20.0', 'scipy~=1.6.0']
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
This should resolve #34 - I tested and installation without any version spec for numpy/scipy (so latest versions were selected) and was able to complete a bed leveling procedure without any apparent malfunction or error (in UI or in logs).

That said, some level of conservativeness is appropriate so in this PR I have locked the versions using the `~=` [version specification](https://packaging.python.org/guides/distributing-packages-using-setuptools/#semantic-versioning-preferred) so that it will take future patch releases, but not new major or minor versions.

Ie, if scipy 1.7 came out this would NOT be selected, but scipy 1.6.* would.