### PR TITLE
MINI+Marlin support, rounding fixes, drop python2, clean readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,59 @@
 # OctoPrint-PrusaLevelingGuide
 
-## Guide
+This plugin provides assistance that will help you level your bed manually.
 
-[Nylock Mod for the MK3S](https://www.rearvuemirror.com/guides/nylock-mod-for-the-mk3s) is an excellent guide written to explain how to apply the nylock mod, but also references this plugin for making adjustments.  I recommend following this guide if you're new to the nylock mod.
+It is intended for use with the Nylock or Silicone mods for Prusa printers but can also be helpful for any printbed that allows adjustments.
 
-**Start here**
-[Bed Leveling without Wave Springs](https://github.com/PrusaOwners/prusaowners/wiki/Bed_Leveling_without_Wave_Springs)
+For each round of adjustment, the plugin will send the configured mesh level code and gcode for retrieving values (generally G80/G81 or G28/G29).
 
-**Dependencies**
-* [python3](https://www.python.org/doc/sunset-python-2/)
-* [scipy](https://www.scipy.org/)
-* [numpy](https://numpy.org/)
+Once values are received, you can view how to adjust your bed then click continue to proceed with another round of leveling or click finish.
 
-**Issues?**
-If installing the plugin, Octoprint displays the plugin as "Unknown" or errors are popping up in the logs, you might need to SSH in and install a dependency.  You can accomplish this by running
+You have the option of viewing the values in a table view or overlayed on a photo of the heatbed.
 
-`sudo apt-get install libatlas-base-dev`
+You can also customize whether you view raw values, degrees, decimal turns, or factional turns.
 
-**IMPORTANT:** The guide mentions a firmware modification for modifying the G81 response to use relative values.  This plugin only works if you **do not** use this modification.  This plugin will calculate the relative values for you.
-
-This plugin is to help guide you through the fine adjustments of the nylock bed leveling method for Prusa MK3 printers, which is described in the above guide.  Make sure you start there and already have the nylocks applied to your bed before beginning.  This plugin allows you to select a profile for preheating, then begin adjustment.  For each round of adjustment, the plugin will send the configured mesh level code and gcode for retrieving values (generally G80; G81).  Once values are received, you can view how to adjust your bed in a number of ways.  You click continue to proceed with another round of leveling or click finish to finish up.
-
-*TODO: Allow configuration of a 'target bed variance' and alert whenever the bed is higher than the target variance - will only work if you configure your print start/print finish gcode to include G81*
-
-You have the option of viewing the values in a table view or overlayed on a photo of the heatbed.  You can also customize whether you view raw values, degrees, decimal turns, or factional turns.
-
-**Table View**
-![Table view](table.png)
-
-
-**Bed View**
-![Bed view](bed.png)
-
-## Inspirations
-
-- [Bed Leveling without Wave Springs](https://github.com/PrusaOwners/prusaowners/wiki/Bed_Leveling_without_Wave_Springs) obviously I would not have written this plugin without this awesome mod/guide
-- [OctoPrint-PrusaMeshMap](https://github.com/PrusaOwners/OctoPrint-PrusaMeshMap) This is the plugin I used previously to adjust my bed.  It works, but I wanted something a little more automated.  Some of the code for detecting g81 response was used from this plugin.
-- [g81_level_guide](https://gitlab.com/gnat.org/g81_level_guide) I like the idea of this script because it automates the process, but I didn't like that it clears my preheat when connecting and that it was a pain to get running on a pi.  The idea inspired me to write this plugin.
-- [g81_relative](https://github.com/pcboy/g81_relative) This is the site I originally used for converting my g81 values to relative numbers.  This is what inspired me to add all the different calculation types.
 
 ## Setup
 
-Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
-or manually using this URL:
+Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager) or manually using this URL:
 
-    https://github.com/scottrini/OctoPrint-PrusaLevelingGuide/archive/master.zip
+https://github.com/scottrini/OctoPrint-PrusaLevelingGuide/archive/master.zip
 
 
-## Configuration
+## Supported Firmware
 
-The configuration tab allows you to customize the gcode for mesh leveling similar to the PrusaMeshMap plugin.
+- PrusaFirmware
+- Marlin/Buddy
 
-![Configuration](settings.png)
 
-## G81 Output Handler
+## Guides
 
-Just like the PrusaMeshMap plugin, this plugin has a handler that is watching output received from the printer **at all times**. This means you can place a G81 in octoprint's or your slicer's start or stop gcode and the plugin will update its values after every print.
+* [Silicone Mod for the MK3](https://www.schweinert.com/silicone-bed-level-mod-prusa-mk3)
+* [Silicone Mod for the MINI](https://github.com/bbbenji/PMSBLM)
+* [Nylock Mod for the MK3S](https://www.rearvuemirror.com/guides/nylock-mod-for-the-mk3s)
+* [Bed Leveling without Wave Springs](https://github.com/PrusaOwners/prusaowners/wiki/Bed_Leveling_without_Wave_Springs)
+
+
+## Dependencies
+* [python3](https://www.python.org/doc/sunset-python-2/)
+* [regex](https://pypi.org/project/regex/)
+* [numpy](https://numpy.org/)
+* [scipy](https://www.scipy.org/)
+
+
+## Known Issues
+* Installation may silently fail due to missing system dependencies. **You should upgrade to OctoPi 0.18+** or SSH into your pi and run the command `sudo apt install libatlas3-base`.
+* This plugin will calculate the relative values for you and will not work with firmware modifications that change the G81 response.
+* Z Calibration can effect bed leveling. If you re-calibrate your Z-axis after leveling your bed, it might look like the whole left or right side of the bed is suddenly higer/lower than the other side. The reason for this is, that the Z-axis leadscrews might have changed their angular position relative to each other due to soft mechanical upper stops. If this is the case, try to rotate one of the leadscrews by hand by one or two clicks instead of re-adjusting the bed again.
+
 
 ## Adjusting your bed
 
-Once your nylocks are on your bed and you're ready to adjust using this plugin, pull up the tab in your octoprint instance.  Decide if you want to preheat the bed while making adjustments.  Preheating isn't absolutely necessary for your initial adjustments, but really fine tuning the bed should be done preheated, as the values will change when things are heated.
+Once you're ready to adjust using this plugin, pull up the tab in your octoprint instance.  Decide if you want to preheat the bed while making adjustments.  Preheating isn't absolutely necessary for your initial adjustments, but really fine tuning the bed should be done preheated, as the values will change when things are heated.
 
 So select your profile and whether to preheat, then click begin adjusting.  The plugin will:
 - Preheat (if enabled)
-- Send the mesh level command and G81 to retrieve results
+- Send the mesh level command and retrieve results
 - Wait for the command to complete
 - Send gcode to move the bed and extruder out of the way
 - Update the UI with the values
@@ -72,8 +62,28 @@ Once the UI is updated, the status will change to *Waiting for continue*.  This 
 
 All of the other views will disable an arrow next to the value to show which direction to rotate the screw.  Once you've made your adjustments, click continue to start another mesh check and update the UI with the new values.  If you've gotten your bed to a variance you're happy with, click **Finished**.  If the printer was preheated, this will disable the preheating.
 
-## Z Calibration can effect bed leveling
 
-Note from *Spacemarine2018*
+## G81/G29 Output Handler
 
-If you re-calibrate your Z-axis after leveling your bed, it might look like the whole left or right side of the bed is suddenly higer/lower than the other side. The reason for this is, that the Z-axis leadscrews might have changed their angular position relative to each other due to soft mechanical upper stops. If this is the case, try to rotate one of the leadscrews by hand by one or two clicks instead of re-adjusting the bed again.
+Just like the PrusaMeshMap plugin, this plugin has a handler that is watching output received from the printer **at all times**. This means you can place a G81 or G29 in octoprint's or your slicer's start or stop gcode and the plugin will update its values after every print.
+
+
+## Screenshots
+
+### Table View
+![Table view](table.png)
+
+### Bed View
+![Bed view](bed.png)
+
+### Configuration
+![Configuration](settings.png)
+
+
+## Inspirations
+
+- [Bed Leveling without Wave Springs](https://github.com/PrusaOwners/prusaowners/wiki/Bed_Leveling_without_Wave_Springs) obviously I would not have written this plugin without this awesome mod/guide
+- [OctoPrint-PrusaMeshMap](https://github.com/PrusaOwners/OctoPrint-PrusaMeshMap) This is the plugin I used previously to adjust my bed.  It works, but I wanted something a little more automated.  Some of the code for detecting g81 response was used from this plugin.
+- [g81_level_guide](https://gitlab.com/gnat.org/g81_level_guide) I like the idea of this script because it automates the process, but I didn't like that it clears my preheat when connecting and that it was a pain to get running on a pi.  The idea inspired me to write this plugin.
+- [g81_relative](https://github.com/pcboy/g81_relative) This is the site I originally used for converting my g81 values to relative numbers.  This is what inspired me to add all the different calculation types.
+- [Prusa Mini Silicone Bed Leveling Mod](https://bbbenji.github.io/PMSBLM/) This calculator inspired an approach to handling even-sized probe grids such as found in the Prusa MINI.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 **Start here**
 [Bed Leveling without Wave Springs](https://github.com/PrusaOwners/prusaowners/wiki/Bed_Leveling_without_Wave_Springs)
 
+**Dependencies**
+* [scipy](https://www.scipy.org/)
+* [numpy](https://numpy.org/)
+
+**Issues?**
+If installing the plugin, Octoprint displays the plugin as "Unknown" or errors are popping up in the logs, you might need to SSH in and install a dependency.  You can accomplish this by running
+
+`sudo apt-get install libatlas-base-dev`
+
 **IMPORTANT:** The guide mentions a firmware modification for modifying the G81 response to use relative values.  This plugin only works if you **do not** use this modification.  This plugin will calculate the relative values for you.
 
 This plugin is to help guide you through the fine adjustments of the nylock bed leveling method for Prusa MK3 printers, which is described in the above guide.  Make sure you start there and already have the nylocks applied to your bed before beginning.  This plugin allows you to select a profile for preheating, then begin adjustment.  For each round of adjustment, the plugin will send the configured mesh level code and gcode for retrieving values (generally G80; G81).  Once values are received, you can view how to adjust your bed in a number of ways.  You click continue to proceed with another round of leveling or click finish to finish up.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 **Start here**
 [Bed Leveling without Wave Springs](https://github.com/PrusaOwners/prusaowners/wiki/Bed_Leveling_without_Wave_Springs)
 
+**Dependencies**
+* [python3](https://www.python.org/doc/sunset-python-2/)
+* [scipy](https://www.scipy.org/)
+* [numpy](https://numpy.org/)
+
+**Issues?**
+If installing the plugin, Octoprint displays the plugin as "Unknown" or errors are popping up in the logs, you might need to SSH in and install a dependency.  You can accomplish this by running
+
+`sudo apt-get install libatlas-base-dev`
+
 **IMPORTANT:** The guide mentions a firmware modification for modifying the G81 response to use relative values.  This plugin only works if you **do not** use this modification.  This plugin will calculate the relative values for you.
 
 This plugin is to help guide you through the fine adjustments of the nylock bed leveling method for Prusa MK3 printers, which is described in the above guide.  Make sure you start there and already have the nylocks applied to your bed before beginning.  This plugin allows you to select a profile for preheating, then begin adjustment.  For each round of adjustment, the plugin will send the configured mesh level code and gcode for retrieving values (generally G80; G81).  Once values are received, you can view how to adjust your bed in a number of ways.  You click continue to proceed with another round of leveling or click finish to finish up.

--- a/octoprint_PrusaLevelingGuide/__init__.py
+++ b/octoprint_PrusaLevelingGuide/__init__.py
@@ -90,7 +90,7 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 		values = RectBivariateSpline(iv, iv, values)([-1,0,1], [-1,0,1])
 		center = values[1][1]
 
-		self.relative_values = np.around(values - center, 3).flatten().tolist()
+		self.relative_values = (values - center).flatten().tolist()
 		self.last_result = time.mktime(datetime.datetime.now().timetuple())			
 
 	##~~ GCode Sent hook

--- a/octoprint_PrusaLevelingGuide/__init__.py
+++ b/octoprint_PrusaLevelingGuide/__init__.py
@@ -127,7 +127,7 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 			
 
 __plugin_name__ = "Prusa Leveling Guide"
-__plugin_pythoncompat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">3.6,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/octoprint_PrusaLevelingGuide/__init__.py
+++ b/octoprint_PrusaLevelingGuide/__init__.py
@@ -6,7 +6,9 @@ import time
 import datetime
 import octoprint.plugin
 import octoprint.printer
-import re
+import regex
+import numpy as np
+from scipy.interpolate import RectBivariateSpline
 
 import flask
 
@@ -19,10 +21,11 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 	
 	
 	def on_after_startup(self):
+		self.mesh_values = []
 		self.bed_variance = None
 		self.relative_values = []
 		self.last_result = None
-		self.regex = re.compile(r"^(  -?\d+.\d+)+$")
+		self.regex = regex.compile(r"^(?<values> +-?\d+\.\d+){7}$|^ \d(?<values> +[+-]?\d+\.\d+){2,}$")
 		self.waiting_for_response = False
 		self.sent_time = False
 
@@ -34,7 +37,6 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 							last_result=self.last_result)
 
 	##~~ SettingsPlugin mixin
-
 	def get_settings_defaults(self):
 		return dict(
 			mesh_gcode = 'G28 W ; home all without mesh bed level\nM400\nG80 N3; mesh bed leveling\nG81 ; check mesh leveling results',
@@ -46,7 +48,6 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 		)
 
 	##~~ AssetPlugin mixin
-
 	def get_assets(self):
 		# Define your plugin's asset files to automatically include in the
 		# core UI here.
@@ -58,7 +59,6 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 		)
 
 	##~~ Softwareupdate hook
-
 	def get_update_information(self):
 		# Define the configuration for your plugin to use with the Software Update
 		# Plugin here. See https://github.com/foosel/OctoPrint/wiki/Plugin:-Software-Update
@@ -78,54 +78,46 @@ class PrusaLevelingGuidePlugin(octoprint.plugin.SimpleApiPlugin,
 				pip="https://github.com/scottrini/OctoPrint-PrusaLevelingGuide/archive/{target_version}.zip"
 			)
 		)
-
-	##~~ GCode Received hook
 	
-	mesh_level_responses = []
-	bed_variance = None
-	relative_values = []
-	last_result = None
-	regex = re.compile(r"^(  -?\d+.\d+)+$")
-	waiting_for_response = False
-	sent_time = False
-	
+	##~~ Generate relative values
 	def mesh_level_generate(self):
-		
-		mesh_values = []
-		
-		for response in self.mesh_level_responses:
-			response = re.sub(r"^[ ]+", "", response)
-			response = re.sub(r"[ ]+", ",", response)
-			for i in response.split(","):
-				mesh_values.append(float(i))
-		
-		self.bed_variance = round(max(mesh_values) - min(mesh_values), 3)
 
-		center = mesh_values[24]
-		
-		self.relative_values = [mesh_values[x] - center for x in [0,3,6,21,24,27,42,45,48]]
-		self.last_result = time.mktime(datetime.datetime.now().timetuple())
-		del self.mesh_level_responses[:]
-		
-		
+		values = np.array(self.mesh_values)
 
+		self.bed_variance = round(values.max() - values.min(), 3)
+
+		ix = np.linspace(-1, 1, len(values))
+		interpolator = RectBivariateSpline(ix, ix, values)
+		values = interpolator([-1,0,1], [-1,0,1])
+		center = values[1][1]
+
+		self.relative_values = np.around(values - center, 3).flatten().tolist()
+		self.last_result = time.mktime(datetime.datetime.now().timetuple())			
+
+	##~~ GCode Sent hook
 	def check_for_mesh_response(self, comm_instance, phase, cmd, cmd_type, gcode, subcode=None, tags=None, *args, **kwargs):
-		if gcode == "G81":
+		if gcode == "G81" or gcode == "G29":
 			self.waiting_for_response = True
 			self.sent_time = time.time()
+			del self.mesh_values[:]
 
+	##~~ GCode Received hook
 	def mesh_level_check(self, comm, line, *args, **kwargs):
-		if not self.waiting_for_response == True:
+		if not hasattr(self, 'waiting_for_response') or not self.waiting_for_response == True:
 			return line
 		
 		if (time.time() - self.sent_time) > 100:
 			self.waiting_for_response = False
 			return line
 
-		if self.regex.match(line.rstrip()):
-			self.mesh_level_responses.append(line)
-			if len(self.mesh_level_responses) == 7:
-				self.mesh_level_generate()
+		m = self.regex.match(line.rstrip())
+		if m:
+			values = [float(value) for value in m.captures("values")]
+			if len(values) > 1:
+				self.mesh_values.append(values)
+				if len(self.mesh_values) == len(values):
+					self.waiting_for_response = False
+					self.mesh_level_generate()
 		return line
 	
 			

--- a/octoprint_PrusaLevelingGuide/static/js/PrusaLevelingGuide.js
+++ b/octoprint_PrusaLevelingGuide/static/js/PrusaLevelingGuide.js
@@ -9,6 +9,7 @@ function gcd(a, b) {
 	return (b) ? gcd(b, a % b) : a;
 }
 var decimalToFraction = function (_decimal) {
+	_decimal = _decimal.toFixed(2); // limit fractional precision
 	if (_decimal == parseInt(_decimal)) {
 		return {
 			top: parseInt(_decimal),
@@ -160,12 +161,12 @@ $(function() {
 		}
  
  		self.convertToDecimalTurns = function (value) {
- 			var turns = (value / 0.5).toFixed(2);
+			var turns = (value / 0.5);
  			return  turns;
  		}
  		
 		self.convertToDegrees = function (value) {
-			var degrees = ((value / 0.5) * 360).toFixed(1);
+			var degrees = ((value / 0.5) * 360);
 			return degrees;
 		}
 		
@@ -213,16 +214,16 @@ $(function() {
 				// determine which view we are using, calculate our value
 				// set our appropriate icon, then add it to the array to update the DOM
 				if (self.selectedView() == "degrees") {
-					var value = self.convertToDegrees(parseFloat(data.values[i]).toFixed(2));
-					newBedValues.push(Math.abs(value)  + '°');
+					var value = self.convertToDegrees(data.values[i]);
+					newBedValues.push(Math.abs(value).toFixed(1) + '°');
 				}
 				else if (self.selectedView() == "decimal") {
 					var value = self.convertToDecimalTurns(data.values[i]);
-					newBedValues.push(Math.abs(value));
+					newBedValues.push(Math.abs(value).toFixed(3));
 				}
 				else if (self.selectedView() == "fraction") {
 					var value = self.convertToDecimalTurns(data.values[i]);
-					var fraction = decimalToFraction(parseFloat(value).toFixed(2));
+					var fraction = decimalToFraction(value);
 					if (fraction.top == 0) {
 						newBedValues.push(0);
 					}
@@ -231,7 +232,7 @@ $(function() {
 					}
 				}
 				else {
-					newBedValues.push(data.values[i]);
+					newBedValues.push(data.values[i].toFixed(3));
 				}
 				self.updateBedValueDirection(i, data.values[i]);
 				

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_PrusaLevelingGuide"
 plugin_name = "OctoPrint-PrusaLevelingGuide"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.15"
+plugin_version = "1.0.16"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">3.6,<4"}
 
 ########################################################################################################################
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_PrusaLevelingGuide"
 plugin_name = "OctoPrint-PrusaLevelingGuide"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.12"
+plugin_version = "1.0.13"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/scottrini/OctoPrint-PrusaLevelingguide"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = []
+plugin_requires = ['regex', 'numpy', 'scipy']
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
I updated my repo so that the default branch includes all of the fixes I've added with a streamlined README.

The main difference from the previous PR is that this one drops Python2 support explicitly to prevent any upgrade issues and encourages users to update to OctoPi 0.18+.

I hope you will be able to merge this or I can leave my fork up for users who want accurate values and/or MINI+Marlin support.